### PR TITLE
Use the latest ilc package again

### DIFF
--- a/dotnet/Native.targets
+++ b/dotnet/Native.targets
@@ -64,7 +64,7 @@
 
     <!-- In AOT builds, add a reference to the IL compiler and link the static native artifact -->
     <ItemGroup Condition=" '$(IsAotBuild)' == 'true' ">
-        <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-27527-01" />
+        <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-*" />
 
         <IlcArg Include="--completetypemetadata" />
         <NativeLibrary Include="$(CargoArtifactPath)" />


### PR DESCRIPTION
Looks like MyGet packages are available again so we can use the latest nightly builds of `ilc`.