### PR TITLE
Refactor native targets so they're independently useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ The most interesting bits for FFI live in the `/native/c` and `/dotnet/Db.Storag
 
 ### Building Rust with MsBuild
 
-The `Native.targets` file contains properties and targets that can call `cargo build` on the native library when building the managed one. It also has compile-time constants for the target platform, and whether or not compilation is ahead-of-time. That way, `dotnet build` and `dotnet publish` can coordinate the complete managed and unmanaged build process in a single invocation.
+The `dotnet/Native.targets` file contains properties and targets that can call `cargo build` on the native library when building the managed one. It attempts to be project-agnostic. It also has compile-time constants for the target platform, and whether or not compilation is ahead-of-time. That way, `dotnet build` and `dotnet publish` can coordinate the complete managed and unmanaged build process in a single invocation.
+
+The `dotnet/Dbc.targets` file is specific for this sample.
 
 ### Calling unmanaged code from .NET
 

--- a/dotnet/Db.Api/Db.Api.csproj
+++ b/dotnet/Db.Api/Db.Api.csproj
@@ -5,7 +5,7 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
-  <Import Project="../Native.targets" />
+  <Import Project="../Dbc.targets" />
 
   <ItemGroup>
     <Folder Include="wwwroot" />

--- a/dotnet/Db.Storage/Db.Storage.csproj
+++ b/dotnet/Db.Storage/Db.Storage.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <Import Project="../Native.targets" />
+  <Import Project="../Dbc.targets" />
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />

--- a/dotnet/Db.Tests/Db.Tests.csproj
+++ b/dotnet/Db.Tests/Db.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <Import Project="../Native.targets" />
+  <Import Project="../Dbc.targets" />
 
   <ItemGroup>
     <ProjectReference Include="../Db.Storage/Db.Storage.csproj" />

--- a/dotnet/Dbc.targets
+++ b/dotnet/Dbc.targets
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <CargoPackage>dbc</CargoPackage>
+        <CargoWorkspacePath>$(MSBuildThisFileDirectory)/..</CargoWorkspacePath>
+    </PropertyGroup>
+
+    <Import Project="Native.targets" />
+</Project>

--- a/dotnet/Native.targets
+++ b/dotnet/Native.targets
@@ -11,12 +11,12 @@
     </PropertyGroup>
 
     <!-- Compile-time RIDs -->
-    <PropertyGroup Condition=" '$(NativeRid)' == 'win81-x64' Or ('$(NativeRid)' == '' And '$([MSBuild]::IsOsPlatform(`WINDOWS`))' == 'true') ">
+    <PropertyGroup Condition=" '$(NativeRid)' == 'win-x64' Or ('$(NativeRid)' == '' And '$([MSBuild]::IsOsPlatform(`WINDOWS`))' == 'true') ">
         <IsWindows>true</IsWindows>
         <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(NativeRid)' == 'ubuntu.18.04-x64' Or '$(NativeRid)' == 'linux-x64' Or ('$(NativeRid)' == '' And '$([MSBuild]::IsOsPlatform(`LINUX`))' == 'true') ">
+    <PropertyGroup Condition=" '$(NativeRid)' == 'linux-x64' Or ('$(NativeRid)' == '' And '$([MSBuild]::IsOsPlatform(`LINUX`))' == 'true') ">
         <IsLinux>true</IsLinux>
         <IsUnix>true</IsUnix>
         <DefineConstants>$(DefineConstants);LINUX;UNIX</DefineConstants>
@@ -32,12 +32,10 @@
     <PropertyGroup>
         <CargoChannel Condition=" $(CargoChannel) == '' ">nightly</CargoChannel>
 
+        <CargoTargetPath>$(MSBuildThisFileDirectory)/../target</CargoTargetPath>
+
         <CargoConfiguration>release</CargoConfiguration>
         <CargoConfiguration Condition=" '$(Configuration)' == 'Debug' ">debug</CargoConfiguration>
-
-        <CargoFlags Condition=" '$(CargoConfiguration)' == 'release' ">$(CargoFlags) --release</CargoFlags>
-        
-        <CargoSkipBuild Condition=" '$(CargoSkipBuild)' == '' ">false</CargoSkipBuild>
 
         <CargoTarget Condition=" '$(IsWindows)' == 'true' ">x86_64-pc-windows-msvc</CargoTarget>
         <CargoTarget Condition=" '$(IsLinux)' == 'true' ">x86_64-unknown-linux-gnu</CargoTarget>
@@ -51,15 +49,20 @@
         <CargoExtension Condition=" '$(IsLinux)' == 'true' And '$(IsAotBuild)' == 'true' ">a</CargoExtension>
         <CargoExtension Condition=" '$(IsMacOS)' == 'true' And '$(IsAotBuild)' == 'true' ">a</CargoExtension>
 
-        <CargoArtifact Condition=" '$(IsWindows)' == 'true' ">dbc.$(CargoExtension)</CargoArtifact>
-        <CargoArtifact Condition=" '$(IsLinux)' == 'true' ">libdbc.$(CargoExtension)</CargoArtifact>
-        <CargoArtifact Condition=" '$(IsMacOS)' == 'true' ">libdbc.$(CargoExtension)</CargoArtifact>
+        <CargoArtifact Condition=" '$(IsWindows)' == 'true' ">$(CargoPackage).$(CargoExtension)</CargoArtifact>
+        <CargoArtifact Condition=" '$(IsLinux)' == 'true' ">lib$(CargoPackage).$(CargoExtension)</CargoArtifact>
+        <CargoArtifact Condition=" '$(IsMacOS)' == 'true' ">lib$(CargoPackage).$(CargoExtension)</CargoArtifact>
 
-        <CargoArtifactPath>$(MSBuildThisFileDirectory)/../target/$(CargoTarget)/$(CargoConfiguration)/$(CargoArtifact)</CargoArtifactPath>
+        <CargoArtifactPath>$(CargoWorkspacePath)/target/$(CargoTarget)/$(CargoConfiguration)/$(CargoArtifact)</CargoArtifactPath>
     </PropertyGroup>
 
+    <ItemGroup>
+        <CargoBuildArg Include="--target $(CargoTarget)" />
+        <CargoBuildArg Condition=" '$(CargoConfiguration)' == 'release' " Include="--release" />
+    </ItemGroup>
+
     <Target Name="Cargo" BeforeTargets="Build">
-        <Exec Command="cargo +$(CargoChannel) build --target $(CargoTarget) $(CargoFlags)" WorkingDirectory="$(MSBuildThisFileDirectory)/.." Condition=" '$(CargoSkipBuild)' == 'false' " />
+        <Exec Command="cargo +$(CargoChannel) build @(CargoBuildArg, ' ')" WorkingDirectory="$(CargoWorkspacePath)" />
     </Target>
 
     <!-- In AOT builds, add a reference to the IL compiler and link the static native artifact -->


### PR DESCRIPTION
- Use an item group for cargo build args
- Split `dbc` specific bits into a separate targets file
