### PR TITLE
Work on integration tests

### DIFF
--- a/Db.sln
+++ b/Db.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Db.Storage", "dotnet\Db.Sto
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Db.Tests", "dotnet\Db.Tests\Db.Tests.csproj", "{EB6323BC-BFFF-46C0-9019-2326180E3A69}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Db.Tests.Integration", "dotnet\Db.Tests.Integration\Db.Tests.Integration.csproj", "{03F7662F-D4FE-42BB-A2C5-58849A8B1BBA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{EB6323BC-BFFF-46C0-9019-2326180E3A69}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB6323BC-BFFF-46C0-9019-2326180E3A69}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB6323BC-BFFF-46C0-9019-2326180E3A69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03F7662F-D4FE-42BB-A2C5-58849A8B1BBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03F7662F-D4FE-42BB-A2C5-58849A8B1BBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03F7662F-D4FE-42BB-A2C5-58849A8B1BBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03F7662F-D4FE-42BB-A2C5-58849A8B1BBA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/ci/linux-x64.ps1
+++ b/ci/linux-x64.ps1
@@ -10,17 +10,30 @@ if ($LastExitCode) { exit 1 }
 # CoreCLR publish
 Clean-OutputDirs
 
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r linux-x64
+dotnet publish `
+    dotnet/Db.Api/Db.Api.csproj `
+    -c Release `
+    -f netcoreapp2.2 `
+    -r linux-x64
 if ($LastExitCode) { exit 1 }
 
-dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/linux-x64/publish/Db.Api
+dotnet run `
+    -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj `
+    -- dotnet/Db.Api/bin/Release/netcoreapp2.2/linux-x64/publish/Db.Api
 if ($LastExitCode) { exit 1 }
 
 # CoreRT publish
 Clean-OutputDirs
 
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r linux-x64 /p:AotBuild=true
+dotnet publish `
+    dotnet/Db.Api/Db.Api.csproj `
+    -c Release `
+    -f netcoreapp2.2 `
+    -r linux-x64 `
+    /p:AotBuild=true
 if ($LastExitCode) { exit 1 }
 
-dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/publish/linux-x64/Db.Api
+dotnet run `
+    -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj `
+    -- dotnet/Db.Api/bin/Release/netcoreapp2.2/linux-x64/publish/Db.Api
 if ($LastExitCode) { exit 1 }

--- a/ci/linux-x64.ps1
+++ b/ci/linux-x64.ps1
@@ -3,12 +3,24 @@ $scriptDir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 . $scriptDir/common.ps1
 
 Clean-OutputDirs
+
 dotnet test
+if ($LastExitCode) { exit 1 }
 
 # CoreCLR publish
 Clean-OutputDirs
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2
+
+dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r linux-x64
+if ($LastExitCode) { exit 1 }
+
+dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/linux-x64/publish/Db.Api
+if ($LastExitCode) { exit 1 }
 
 # CoreRT publish
 Clean-OutputDirs
+
 dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r linux-x64 /p:AotBuild=true
+if ($LastExitCode) { exit 1 }
+
+dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/publish/linux-x64/Db.Api
+if ($LastExitCode) { exit 1 }

--- a/ci/osx-x64.ps1
+++ b/ci/osx-x64.ps1
@@ -3,12 +3,24 @@ $scriptDir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 . $scriptDir/common.ps1
 
 Clean-OutputDirs
+
 dotnet test
+if ($LastExitCode) { exit 1 }
 
 # CoreCLR publish
 Clean-OutputDirs
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2
+
+dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r osx-x64
+if ($LastExitCode) { exit 1 }
+
+dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/osx-x64/publish/Db.Api
+if ($LastExitCode) { exit 1 }
 
 # CoreRT publish
 Clean-OutputDirs
+
 dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r osx-x64 /p:AotBuild=true
+if ($LastExitCode) { exit 1 }
+
+dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/publish/osx-x64/Db.Api
+if ($LastExitCode) { exit 1 }

--- a/ci/osx-x64.ps1
+++ b/ci/osx-x64.ps1
@@ -10,17 +10,30 @@ if ($LastExitCode) { exit 1 }
 # CoreCLR publish
 Clean-OutputDirs
 
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r osx-x64
+dotnet publish `
+    dotnet/Db.Api/Db.Api.csproj `
+    -c Release `
+    -f netcoreapp2.2 `
+    -r osx-x64
 if ($LastExitCode) { exit 1 }
 
-dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/osx-x64/publish/Db.Api
+dotnet run `
+    -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj `
+    -- dotnet/Db.Api/bin/Release/netcoreapp2.2/osx-x64/publish/Db.Api
 if ($LastExitCode) { exit 1 }
 
 # CoreRT publish
 Clean-OutputDirs
 
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r osx-x64 /p:AotBuild=true
+dotnet publish `
+    dotnet/Db.Api/Db.Api.csproj `
+    -c Release `
+    -f netcoreapp2.2 `
+    -r osx-x64 `
+    /p:AotBuild=true
 if ($LastExitCode) { exit 1 }
 
-dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/publish/osx-x64/Db.Api
+dotnet run `
+    -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj `
+    -- dotnet/Db.Api/bin/Release/netcoreapp2.2/osx-x64/publish/Db.Api
 if ($LastExitCode) { exit 1 }

--- a/ci/win-x64.ps1
+++ b/ci/win-x64.ps1
@@ -3,12 +3,24 @@ $scriptDir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 . $scriptDir/common.ps1
 
 Clean-OutputDirs
+
 dotnet test
+if ($LastExitCode) { exit 1 }
 
 # CoreCLR publish
 Clean-OutputDirs
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2
+
+dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r win-x64
+if ($LastExitCode) { exit 1 }
+
+dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/win-x64/publish/Db.Api.exe
+if ($LastExitCode) { exit 1 }
 
 # CoreRT publish
 Clean-OutputDirs
+
 dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r win-x64 /p:AotBuild=true
+if ($LastExitCode) { exit 1 }
+
+dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/publish/win-x64/Db.Api.exe
+if ($LastExitCode) { exit 1 }

--- a/ci/win-x64.ps1
+++ b/ci/win-x64.ps1
@@ -10,17 +10,30 @@ if ($LastExitCode) { exit 1 }
 # CoreCLR publish
 Clean-OutputDirs
 
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r win-x64
+dotnet publish `
+    dotnet/Db.Api/Db.Api.csproj `
+    -c Release `
+    -f netcoreapp2.2 `
+    -r win-x64
 if ($LastExitCode) { exit 1 }
 
-dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/win-x64/publish/Db.Api.exe
+dotnet run `
+    -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj `
+    -- dotnet/Db.Api/bin/Release/netcoreapp2.2/win-x64/publish/Db.Api.exe
 if ($LastExitCode) { exit 1 }
 
 # CoreRT publish
 Clean-OutputDirs
 
-dotnet publish dotnet/Db.Api/Db.Api.csproj -c Release -f netcoreapp2.2 -r win-x64 /p:AotBuild=true
+dotnet publish `
+    dotnet/Db.Api/Db.Api.csproj `
+    -c Release `
+    -f netcoreapp2.2 `
+    -r win-x64 `
+    /p:AotBuild=true
 if ($LastExitCode) { exit 1 }
 
-dotnet run -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj -- dotnet/Db.Api/bin/Release/netcoreapp2.2/publish/win-x64/Db.Api.exe
+dotnet run `
+    -p dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj `
+    -- dotnet/Db.Api/bin/Release/netcoreapp2.2/win-x64/publish/Db.Api.exe
 if ($LastExitCode) { exit 1 }

--- a/dotnet/Db.Api/Startup.cs
+++ b/dotnet/Db.Api/Startup.cs
@@ -18,15 +18,15 @@ namespace Db.Api
 
         public IConfiguration Configuration { get; }
 
+        public string DataPath => Configuration["datapath"] ?? Configuration.GetSection("Data")["Path"] ?? "dbdata";
+
         public void ConfigureServices(IServiceCollection services)
         {
             var applicationPartManager = new ApplicationPartManager();
             applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(Startup).Assembly));
             services.Add(new ServiceDescriptor(typeof(ApplicationPartManager), applicationPartManager));
 
-            var dataPath = Configuration.GetSection("Data")["Path"];
-
-            services.AddSingleton(new DataStore(MemoryPool<byte>.Shared, Store.Open(dataPath)));
+            services.AddSingleton(new DataStore(MemoryPool<byte>.Shared, Store.Open(DataPath)));
 
             services.AddMvcCore().AddJsonFormatters();
         }

--- a/dotnet/Db.Tests.Integration/Api/Client.cs
+++ b/dotnet/Db.Tests.Integration/Api/Client.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Db.Tests.Integration.Api
+{
+    class Client : IDisposable
+    {
+        readonly Uri _baseUri;
+        readonly HttpClient _client;
+
+        public Client(string baseUri)
+        {
+            _client = new HttpClient(new HttpClientHandler());
+            _baseUri = new Uri(baseUri);
+        }
+
+        public void Dispose()
+        {
+            _client.Dispose();
+        }
+
+        public async Task<Data[]> GetAll()
+        {
+            var response = await _client.GetAsync(new Uri(_baseUri, "api/data"));
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync();
+
+            return JsonConvert.DeserializeObject<Data[]>(content);
+        }
+
+        public async Task Set(Data data)
+        {
+            var content = new ByteArrayContent(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data.Value)));
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            var response = await _client.PostAsync(new Uri(_baseUri, $"api/data/{data.Key}"), content);
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/dotnet/Db.Tests.Integration/Api/Data.cs
+++ b/dotnet/Db.Tests.Integration/Api/Data.cs
@@ -1,0 +1,16 @@
+namespace Db.Tests.Integration.Api
+{
+    class Data
+    {
+        public Data(string key, object value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public string Key { get; set; }
+        public object Value { get; set; }
+
+        public dynamic DynamicValue => Value;
+    }
+}

--- a/dotnet/Db.Tests.Integration/Cases/SetGetData.cs
+++ b/dotnet/Db.Tests.Integration/Cases/SetGetData.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using Db.Tests.Integration.Api;
+using Db.Tests.Integration.Support;
+using Xunit;
+
+namespace Db.Tests.Integration.Cases
+{
+    class SetGetData : ITestCase
+    {
+        public async Task Execute(Client client)
+        {
+            var id = "testdocs-1";
+            var value = Guid.NewGuid().ToString();
+
+            await client.Set(new Data(id, new {value}));
+
+            var created = await client.GetAll();
+
+            Assert.Equal(1, created.Length);
+            Assert.Equal(value, (string) created[0].DynamicValue.value);
+        }
+    }
+}

--- a/dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj
+++ b/dotnet/Db.Tests.Integration/Db.Tests.Integration.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.9.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/Db.Tests.Integration/Program.cs
+++ b/dotnet/Db.Tests.Integration/Program.cs
@@ -1,0 +1,19 @@
+﻿using Autofac;
+using Db.Tests.Integration.Support;
+
+namespace Db.Tests.Integration
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterModule(new TestCaseRunnerModule(args[0]));
+
+            using (var container = builder.Build())
+            {
+                return container.Resolve<TestCaseRunner>().Run();
+            }
+        }
+    }
+}

--- a/dotnet/Db.Tests.Integration/Support/DataPath.cs
+++ b/dotnet/Db.Tests.Integration/Support/DataPath.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Db.Tests.Integration.Support
+{
+    public class DataPath : IDisposable
+    {
+        readonly string _dir;
+
+        public DataPath()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_dir))
+                Directory.Delete(_dir, true);
+        }
+
+        public static implicit operator string(DataPath @this)
+        {
+            return @this._dir;
+        }
+
+        public override string ToString()
+        {
+            return _dir;
+        }
+    }
+}

--- a/dotnet/Db.Tests.Integration/Support/ITestCase.cs
+++ b/dotnet/Db.Tests.Integration/Support/ITestCase.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Db.Tests.Integration.Api;
+
+namespace Db.Tests.Integration.Support
+{
+    interface ITestCase
+    {
+        Task Execute(Client client);
+    }
+}

--- a/dotnet/Db.Tests.Integration/Support/ListenUrl.cs
+++ b/dotnet/Db.Tests.Integration/Support/ListenUrl.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+
+namespace Db.Tests.Integration.Support
+{
+    class ListenUrl
+    {
+        static int NextPort = 50000;
+        readonly string _value;
+
+        public ListenUrl()
+        {
+            _value = $"http://localhost:{GetNextPort()}";
+        }
+
+        static int GetNextPort()
+        {
+            return Interlocked.Increment(ref NextPort);
+        }
+
+        public static implicit operator string(ListenUrl @this)
+        {
+            return @this._value;
+        }
+
+        public override string ToString()
+        {
+            return _value;
+        }
+    }
+}

--- a/dotnet/Db.Tests.Integration/Support/ServerProcess.cs
+++ b/dotnet/Db.Tests.Integration/Support/ServerProcess.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace Db.Tests.Integration.Support
+{
+    class ServerProcess : IDisposable
+    {
+        readonly ManualResetEvent _errorComplete = new ManualResetEvent(false);
+        readonly StringWriter _output = new StringWriter();
+        readonly ManualResetEvent _outputComplete = new ManualResetEvent(false);
+        readonly Process _process;
+
+        readonly object _sync = new object();
+
+        public ServerProcess(string binPath, string listenUrl, string dataPath)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                StandardOutputEncoding = new UTF8Encoding(false),
+                StandardErrorEncoding = new UTF8Encoding(false),
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                FileName = binPath,
+                Arguments = $"--urls \"{listenUrl}\" --datapath \"{dataPath}\""
+            };
+
+            _process = Process.Start(startInfo);
+
+            if (_process == null) throw new InvalidOperationException("Failed to start server");
+
+            _process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data == null)
+                    _outputComplete.Set();
+                else
+                    WriteOutput(e.Data);
+            };
+            _process.BeginOutputReadLine();
+
+            _process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data == null)
+                    _errorComplete.Set();
+                else
+                    WriteOutput(e.Data);
+            };
+            _process.BeginErrorReadLine();
+        }
+
+        public string Output
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _output.ToString();
+                }
+            }
+        }
+
+        public bool HasExited => _process.HasExited;
+
+        public void Dispose()
+        {
+            try
+            {
+                _process.Kill();
+                WaitForExit();
+            }
+            catch
+            {
+                // Ignored
+            }
+        }
+
+        void WriteOutput(string line)
+        {
+            lock (_sync)
+            {
+                _output.WriteLine(line);
+            }
+        }
+
+        public int WaitForExit(TimeSpan? timeout = null)
+        {
+            _process.WaitForExit((int) (timeout ?? Timeout.InfiniteTimeSpan).TotalMilliseconds);
+
+            if (!_outputComplete.WaitOne(TimeSpan.FromSeconds(30)))
+                throw new IOException("STDOUT did not complete in time");
+
+            if (!_errorComplete.WaitOne(TimeSpan.FromSeconds(30)))
+                throw new IOException("STDERR did not complete in time");
+
+            return _process.ExitCode;
+        }
+    }
+}

--- a/dotnet/Db.Tests.Integration/Support/TestCase.cs
+++ b/dotnet/Db.Tests.Integration/Support/TestCase.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using Db.Tests.Integration.Api;
+
+namespace Db.Tests.Integration.Support
+{
+    sealed class TestCase
+    {
+        readonly Client _client;
+        readonly ServerProcess _server;
+        readonly ITestCase _test;
+
+        public TestCase(ITestCase test, ServerProcess server, Client client)
+        {
+            _test = test;
+            _server = server;
+            _client = client;
+        }
+
+        public string ServerOutput => _server.Output;
+        public string Name => _test.GetType().FullName;
+
+        public async Task Execute()
+        {
+            // Give the server time to start up
+            // If it isn't running then fail
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            if (_server.HasExited) throw new Exception("The server process has already exited");
+
+            await _test.Execute(_client);
+        }
+    }
+}

--- a/dotnet/Db.Tests.Integration/Support/TestCaseRunner.cs
+++ b/dotnet/Db.Tests.Integration/Support/TestCaseRunner.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac.Features.OwnedInstances;
+using Db.Tests.Integration.Support;
+
+namespace Db.Tests.Integration.Support
+{
+    class TestCaseRunner
+    {
+        readonly IEnumerable<Func<Owned<TestCase>>> _tests;
+
+        public TestCaseRunner(IEnumerable<Func<Owned<TestCase>>> tests)
+        {
+            _tests = tests;
+        }
+
+        public int Run()
+        {
+            var results = new ConcurrentBag<string>();
+            var success = true;
+
+            // Randomize the order of the test cases
+            var testsToRun = _tests.OrderBy(_ => Guid.NewGuid());
+
+            Parallel.ForEach(testsToRun, new ParallelOptions {MaxDegreeOfParallelism = 4},
+                (testFactory, state) =>
+                {
+                    using (var test = testFactory())
+                    {
+                        try
+                        {
+                            test.Value.Execute().GetAwaiter().GetResult();
+                            results.Add($"PASS {test.Value.Name}\n{test.Value.ServerOutput}");
+                        }
+                        catch (Exception e)
+                        {
+                            success = false;
+                            results.Add($"FAIL {test.Value.Name}\n{e}\n{test.Value.ServerOutput}");
+                        }
+                    }
+                });
+
+            foreach (var result in results) Console.WriteLine(result);
+
+            return success ? 0 : 1;
+        }
+    }
+}

--- a/dotnet/Db.Tests.Integration/Support/TestCaseRunnerModule.cs
+++ b/dotnet/Db.Tests.Integration/Support/TestCaseRunnerModule.cs
@@ -1,0 +1,39 @@
+using Autofac;
+using Db.Tests.Integration.Api;
+using Db.Tests.Integration.Support;
+
+namespace Db.Tests.Integration.Support
+{
+    public class TestCaseRunnerModule : Module
+    {
+        readonly string _binPath;
+
+        public TestCaseRunnerModule(string binPath)
+        {
+            _binPath = binPath;
+        }
+
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterAssemblyTypes(ThisAssembly)
+                .As<ITestCase>();
+
+            builder.RegisterType<TestCaseRunner>();
+
+            builder.RegisterType<DataPath>().InstancePerOwned<TestCase>();
+            builder.RegisterType<ListenUrl>().InstancePerOwned<TestCase>();
+
+            builder.Register(ctx =>
+                    new ServerProcess(_binPath, ctx.Resolve<ListenUrl>(), ctx.Resolve<DataPath>()))
+                .As<ServerProcess>()
+                .InstancePerOwned<TestCase>();
+
+            builder.Register(ctx => new Client(ctx.Resolve<ListenUrl>()))
+                .As<Client>()
+                .InstancePerOwned<TestCase>();
+
+            builder.RegisterAdapter<ITestCase, TestCase>((ctx, test) =>
+                new TestCase(test, ctx.Resolve<ServerProcess>(), ctx.Resolve<Client>()));
+        }
+    }
+}

--- a/native/std_ext/mod.rs
+++ b/native/std_ext/mod.rs
@@ -5,6 +5,8 @@ These modules don't exist as a separate crate
 so the API can remain private.
 */
 
+#![allow(dead_code)]
+
 #[macro_use]
 mod macros;
 


### PR DESCRIPTION
For CoreRT, we don't know if the contents of our `rd.xml` cover all our reflection usecases unless we actually try running the code (it's depressing).

This PR lays the groundwork for some integration tests, which I'll add before merging.