### PR TITLE
Rename HandleOwned to HandleExclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Handles in the Rust C ABI try to model the way C# _can_ interact with them rathe
 - If an unmanaged resource is not manually disposed and reaches finalization, the .NET runtime will attempt to free it from a different thread than the one that created it. The unmanaged resource will be effectively _moved_ into the finalization thread.
 - C#'s `SafeHandle` can protect an unmanaged resource from being used before it's been allocated or after it's been freed.
 
-These constraints lead to the `HandleShared` and `HandleOwned` types that are used in the C bindings.
+These constraints lead to the `HandleShared` and `HandleExclusive` types that are used in the C bindings.
 
 ### Calling unmanaged code from .NET
 

--- a/native/c/src/is_null.rs
+++ b/native/c/src/is_null.rs
@@ -29,7 +29,7 @@ impl<T: ?Sized> IsNull for *mut T {
     }
 }
 
-impl<T: ?Sized> IsNull for super::HandleOwned<T> {
+impl<T: ?Sized> IsNull for super::HandleExclusive<T> {
     fn is_null(&self) -> bool {
         self.as_ptr().is_null()
     }

--- a/native/c/src/lib.rs
+++ b/native/c/src/lib.rs
@@ -58,21 +58,21 @@ pub struct DbReader {
     inner: thread_bound::DeferredCleanup<store::reader::Reader>,
 }
 
-pub type DbReaderHandle = HandleOwned<DbReader>;
+pub type DbReaderHandle = HandleExclusive<DbReader>;
 
 #[repr(C)]
 pub struct DbWriter {
     inner: store::writer::Writer,
 }
 
-pub type DbWriterHandle = HandleOwned<DbWriter>;
+pub type DbWriterHandle = HandleExclusive<DbWriter>;
 
 #[repr(C)]
 pub struct DbDeleter {
     inner: store::deleter::Deleter,
 }
 
-pub type DbDeleterHandle = HandleOwned<DbDeleter>;
+pub type DbDeleterHandle = HandleExclusive<DbDeleter>;
 
 ffi_no_catch! {
     fn db_last_result(


### PR DESCRIPTION
Just so that it's more semantically accurate, since the handle is like `&mut T` rather than `T`.