### PR TITLE
Add an id to last results that fail

### DIFF
--- a/dotnet/Db.Storage/Native/Bindings.cs
+++ b/dotnet/Db.Storage/Native/Bindings.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleToAttribute("Db.Tests")]
 
 namespace Db.Storage.Native
 {
-    static class Bindings
+    internal static class Bindings
     {
 #if AOT
         const string NativeLibrary = "*";
@@ -156,6 +159,26 @@ namespace Db.Storage.Native
         {
             return MaybeCheck(_db_delete_end(deleter), check);
         }
+
+#if DEBUG
+        [DllImport(NativeLibrary, EntryPoint = "db_test_error", ExactSpelling = true,
+            CallingConvention = CallingConvention.Cdecl)]
+        private static extern DbResult _db_test_error();
+
+        public static DbResult db_test_error(bool check = true)
+        {
+            return MaybeCheck(_db_test_error(), check);
+        }
+        
+        [DllImport(NativeLibrary, EntryPoint = "db_test_ok", ExactSpelling = true,
+            CallingConvention = CallingConvention.Cdecl)]
+        private static extern DbResult _db_test_ok();
+
+        public static DbResult db_test_ok(bool check = true)
+        {
+            return MaybeCheck(_db_test_ok(), check);
+        }
+#endif
 
         private static DbResult MaybeCheck(DbResult result, bool check)
         {

--- a/dotnet/Db.Tests/Storage/LastErrorTests.cs
+++ b/dotnet/Db.Tests/Storage/LastErrorTests.cs
@@ -1,0 +1,39 @@
+#if DEBUG
+using System;
+using Xunit;
+using Db.Storage.Native;
+
+namespace Db.Tests.Storage
+{
+    public class LastResultTests
+    {
+        [Fact]
+        public void NativeErrorsBecomeExceptions()
+        {
+            var nativeException = Assert.Throws<Exception>(() => Bindings.db_test_error());
+            
+            Assert.Equal("Native storage failed (InternalError), A test error.", nativeException.Message);
+        }
+
+        [Fact]
+        public void NativeErrorsUseDefaultMessageWhenLastResultChangesToOk()
+        {
+            var nativeResult = Bindings.db_test_error(false);
+            Bindings.db_test_ok();
+
+            var nativeException = Assert.Throws<Exception>(() => nativeResult.Check());
+            Assert.Equal("Native storage failed with InternalError", nativeException.Message);
+        }
+        
+        [Fact]
+        public void NativeErrorsUseDefaultMessageWhenLastResultChangesToNewError()
+        {
+            var nativeResult = Bindings.db_test_error(false);
+            Bindings.db_test_error(false);
+            
+            var nativeException = Assert.Throws<Exception>(() => nativeResult.Check());
+            Assert.Equal("Native storage failed with InternalError", nativeException.Message);
+        }
+    }
+}
+#endif

--- a/native/c/src/handle.rs
+++ b/native/c/src/handle.rs
@@ -106,7 +106,7 @@ impl<T: ?Sized> HandleExclusive<T> {
 
 impl<T> HandleExclusive<T>
 where
-    HandleExclusive<T>: Send,
+    HandleExclusive<T>: Send  + Sync,
 {
     pub(super) fn alloc(value: T) -> Self
     where

--- a/native/c/src/macros.rs
+++ b/native/c/src/macros.rs
@@ -18,7 +18,7 @@ macro_rules! ffi {
                 fn call( $(mut $arg_ident: $arg_ty),* ) -> DbResult {
                     $(
                         if $crate::is_null::IsNull::is_null(&$arg_ident) {
-                            return DbResult::ArgumentNull.context($crate::is_null::Error { arg: stringify!($arg_ident) });
+                            return DbResult::argument_null().context($crate::is_null::Error { arg: stringify!($arg_ident) });
                         }
                     )*
 
@@ -42,7 +42,7 @@ macro_rules! ffi_no_catch {
                 fn call( $(mut $arg_ident: $arg_ty),* ) -> DbResult {
                     $(
                         if $crate::is_null::IsNull::is_null(&$arg_ident) {
-                            return DbResult::ArgumentNull.context($crate::is_null::Error { arg: stringify!($arg_ident) });
+                            return DbResult::argument_null().context($crate::is_null::Error { arg: stringify!($arg_ident) });
                         }
                     )*
 

--- a/native/c/src/read.rs
+++ b/native/c/src/read.rs
@@ -59,12 +59,12 @@ pub(super) fn into_fixed_buffer(
     if written > buf.len() {
         *actual_value_len = written;
 
-        DbResult::BufferTooSmall
+        DbResult::buffer_too_small()
     // The entire payload fit in the buffer
     } else {
         *actual_value_len = written;
         *key = DbKey(data.key.to_bytes());
 
-        DbResult::Ok
+        DbResult::ok()
     }
 }

--- a/native/c/src/thread_bound.rs
+++ b/native/c/src/thread_bound.rs
@@ -95,6 +95,8 @@ impl<T: ?Sized> ThreadBound<T> {
     }
 }
 
+// NOTE: The `Send` impl for `ThreadBound` is still determined by `T`
+
 unsafe_impl!("The inner value can't actually be accessed concurrently" => impl<T: ?Sized> Sync for ThreadBound<T> {});
 
 impl<T: ?Sized> Deref for ThreadBound<T> {


### PR DESCRIPTION
Closes #19 

Adds an id to the last results captured in FFI so that we can be tighter about checking them. This adds some overhead to error paths, but they're not on the happy path.