### PR TITLE
Fix up a soundness issue with DeferredCleanup

### DIFF
--- a/native/c/src/handle.rs
+++ b/native/c/src/handle.rs
@@ -189,18 +189,16 @@ impl RefMut<u8> {
 
 /**
 An uninitialized, assignable out parameter.
-
-The inner value is not guaranteed to be initialized.
 */
 #[repr(transparent)]
 pub struct Out<T: ?Sized>(*mut T);
 
 impl<T> Out<T> {
-    unsafe_fn!("The pointer must be nonnull and valid for writes" => pub fn assign(&mut self, value: T) {
+    unsafe_fn!("The pointer must be nonnull and valid for writes" => pub fn init(&mut self, value: T) {
         ptr::write(self.0, value);
     });
 
-    unsafe_fn!("The pointer must be nonnull, not overlap the slice, must be valid for the length of the slice, and valid for writes" => pub fn assign_slice(&mut self, value: &[T]) {
+    unsafe_fn!("The pointer must be nonnull, not overlap the slice, must be valid for the length of the slice, and valid for writes" => pub fn init_slice(&mut self, value: &[T]) {
         ptr::copy_nonoverlapping(value.as_ptr(), self.0, value.len());
     });
 }

--- a/native/c/src/lib.rs
+++ b/native/c/src/lib.rs
@@ -81,18 +81,18 @@ ffi_no_catch! {
         DbResult::with_last_result(|last_result| {
             let (value, error) = last_result.unwrap_or((DbResult::ok(), None));
 
-            unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => result.assign(value));
+            unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => result.init(value));
 
             if let Some(error) = error {
-                unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => actual_message_len.assign(error.len()));
+                unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => actual_message_len.init(error.len()));
 
                 if message_buf_len < error.len() {
                     return DbResult::buffer_too_small();
                 }
 
-                unsafe_block!("The buffer lives as long as `db_last_result` and the length is within the buffer" => message_buf.assign_slice(error.as_bytes()));
+                unsafe_block!("The buffer is valid for writes and the length is within the buffer" => message_buf.init_slice(error.as_bytes()));
             } else {
-                unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => actual_message_len.assign(0));
+                unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => actual_message_len.init(0));
             }
 
             DbResult::ok()
@@ -109,7 +109,7 @@ ffi! {
             inner: store::Store::open(path)?,
         });
 
-        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => store.assign(handle));
+        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => store.init(handle));
 
         DbResult::ok()
     }
@@ -130,7 +130,7 @@ ffi! {
             inner: thread_bound::DeferredCleanup::new(store.inner.read_begin()?),
         });
 
-        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => reader.assign(handle));
+        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => reader.init(handle));
 
         DbResult::ok()
     }
@@ -192,7 +192,7 @@ ffi! {
             inner: store.inner.write_begin()?,
         });
 
-        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => writer.assign(handle));
+        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => writer.init(handle));
 
         DbResult::ok()
     }
@@ -232,7 +232,7 @@ ffi! {
             inner: store.inner.delete_begin()?,
         });
 
-        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => deleter.assign(handle));
+        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => deleter.init(handle));
 
         DbResult::ok()
     }

--- a/native/c/src/read.rs
+++ b/native/c/src/read.rs
@@ -58,13 +58,13 @@ pub(super) fn into_fixed_buffer(
 
     // If we wrote more bytes than the buffer could fit, return the required size
     if written > buf.len() {
-        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => actual_value_len.assign(written));
+        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => actual_value_len.init(written));
 
         DbResult::buffer_too_small()
     // The entire payload fit in the buffer
     } else {
-        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => actual_value_len.assign(written));
-        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => key.assign(DbKey(data.key.to_bytes())));
+        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => actual_value_len.init(written));
+        unsafe_block!("The out pointer is valid and not mutably aliased elsewhere" => key.init(DbKey(data.key.to_bytes())));
 
         DbResult::ok()
     }


### PR DESCRIPTION
The `DeferredCleanup` wrapper lets us signal that a value needs to be dropped while it's pinned to a different thread. Because that value might live for the duration of the thread that holds it we need to require `T: 'static`.

It's possibly still iffy because we'll basically call `drop` twice.