### PR TITLE
Add a lifetime to ptr newtypes

### DIFF
--- a/native/c/src/handle.rs
+++ b/native/c/src/handle.rs
@@ -9,6 +9,7 @@ use std::{
     },
     ptr,
     slice,
+    marker::PhantomData,
 };
 
 use super::{
@@ -155,15 +156,20 @@ where
 An initialized parameter passed by shared reference.
 */
 #[repr(transparent)]
-pub struct Ref<T: ?Sized>(*const T);
+pub struct Ref<'a, T: ?Sized>(*const T, PhantomData<&'a T>);
 
-impl<T: ?Sized> Ref<T> {
+impl<'a, T: ?Sized + RefUnwindSafe> UnwindSafe for Ref<'a, T> {}
+
+unsafe_impl!("The handle is semantically `&mut T`" => impl<'a, T: ?Sized> Send for Ref<'a, T> where &'a T: Send {});
+unsafe_impl!("The handle uses `ThreadBound` for synchronization" => impl<'a, T: ?Sized> Sync for Ref<'a, T> where &'a T: Sync {});
+
+impl<'a, T: ?Sized> Ref<'a, T> {
     unsafe_fn!("The pointer must be nonnull and will remain valid" => pub fn as_ref(&self) -> &T {
         &*self.0
     });
 }
 
-impl Ref<u8> {
+impl<'a> Ref<'a, u8> {
     unsafe_fn!("The pointer must be nonnull, the length is correct, and will remain valid" => pub fn as_bytes(&self, len: usize) -> &[u8] {
         slice::from_raw_parts(self.0, len)
     });
@@ -173,15 +179,20 @@ impl Ref<u8> {
 An initialized parameter passed by exclusive reference.
 */
 #[repr(transparent)]
-pub struct RefMut<T: ?Sized>(*mut T);
+pub struct RefMut<'a, T: ?Sized>(*mut T, PhantomData<&'a mut T>);
 
-impl<T: ?Sized> RefMut<T> {
+impl<'a, T: ?Sized + RefUnwindSafe> UnwindSafe for RefMut<'a, T> {}
+
+unsafe_impl!("The handle is semantically `&mut T`" => impl<'a, T: ?Sized> Send for RefMut<'a, T> where &'a mut T: Send {});
+unsafe_impl!("The handle uses `ThreadBound` for synchronization" => impl<'a, T: ?Sized> Sync for RefMut<'a, T> where &'a mut T: Sync {});
+
+impl<'a, T: ?Sized> RefMut<'a, T> {
     unsafe_fn!("The pointer must be nonnull and will remain valid" => pub fn as_mut(&mut self) -> &mut T {
         &mut *self.0
     });
 }
 
-impl RefMut<u8> {
+impl<'a> RefMut<'a, u8> {
     unsafe_fn!("The pointer must be nonnull, the length is correct, and will remain valid" => pub fn as_bytes_mut(&mut self, len: usize) -> &mut [u8] {
         slice::from_raw_parts_mut(self.0, len)
     });
@@ -191,9 +202,14 @@ impl RefMut<u8> {
 An uninitialized, assignable out parameter.
 */
 #[repr(transparent)]
-pub struct Out<T: ?Sized>(*mut T);
+pub struct Out<'a, T: ?Sized>(*mut T, PhantomData<&'a mut T>);
 
-impl<T> Out<T> {
+impl<'a, T: ?Sized + RefUnwindSafe> UnwindSafe for Out<'a, T> {}
+
+unsafe_impl!("The handle is semantically `&mut T`" => impl<'a, T: ?Sized> Send for Out<'a, T> where &'a mut T: Send {});
+unsafe_impl!("The handle uses `ThreadBound` for synchronization" => impl<'a, T: ?Sized> Sync for Out<'a, T> where &'a mut T: Sync {});
+
+impl<'a, T> Out<'a, T> {
     unsafe_fn!("The pointer must be nonnull and valid for writes" => pub fn init(&mut self, value: T) {
         ptr::write(self.0, value);
     });
@@ -203,7 +219,7 @@ impl<T> Out<T> {
     });
 }
 
-impl Out<u8> {
+impl<'a> Out<'a, u8> {
     unsafe_fn!("The slice must never be read from and must be valid for the length of the slice" => pub fn as_uninit_bytes_mut(&mut self, len: usize) -> &mut [u8] {
         slice::from_raw_parts_mut(self.0, len)
     });
@@ -221,19 +237,19 @@ impl<T: ?Sized + Sync> IsNull for HandleShared<T> {
     }
 }
 
-impl<T: ?Sized> IsNull for Ref<T> {
+impl<'a, T: ?Sized> IsNull for Ref<'a, T> {
     fn is_null(&self) -> bool {
         self.0.is_null()
     }
 }
 
-impl<T: ?Sized + Sync> IsNull for RefMut<T> {
+impl<'a, T: ?Sized + Sync> IsNull for RefMut<'a, T> {
     fn is_null(&self) -> bool {
         self.0.is_null()
     }
 }
 
-impl<T: ?Sized> IsNull for Out<T> {
+impl<'a, T: ?Sized> IsNull for Out<'a, T> {
     fn is_null(&self) -> bool {
         self.0.is_null()
     }


### PR DESCRIPTION
This makes sure we can't squirrel away a reference that might've been pinned in .NET for longer than the duration of our FFI function. You could still just declare your `Ref<T>` as `Ref<'static, T>` but at least then it's pretty clear you're up to something weird.