### PR TITLE
Make thread_bound a submodule of handle

### DIFF
--- a/native/c/src/handle/mod.rs
+++ b/native/c/src/handle/mod.rs
@@ -8,10 +8,10 @@ use std::{
     marker::PhantomData,
 };
 
-use super::{
-    is_null::IsNull,
-    thread_bound::ThreadBound,
-};
+pub(crate) mod thread_bound;
+
+use self::thread_bound::ThreadBound;
+use super::is_null::IsNull;
 
 /*
 The handles here are wrappers for a shared `&T` and an exclusive `&mut T`.
@@ -65,9 +65,9 @@ A non-shared handle that cannot be accessed by multiple threads.
 The interior value can be treated like `&mut T`.
 
 The handle is bound to the thread that it was created on to ensure
-there's no possibility for data races. Note that this doesn't rule out
-the possibility of multiple live mutable aliases to the same handle, even
-though memory accesses themselves will be safe.
+there's no possibility for data races. Note that, if reverse PInvoke is supported
+then it's possible to mutably alias the handle from the same thread if the reverse
+call can re-enter the FFI using the same handle. This is technically undefined behaviour.
 
 The handle _can_ be deallocated from a different thread than the one that created it.
 

--- a/native/c/src/handle/mod.rs
+++ b/native/c/src/handle/mod.rs
@@ -48,7 +48,7 @@ where
         HandleShared(Box::into_raw(v), PhantomData)
     }
 
-    pub(super) fn get(self) -> &'a T {
+    pub(super) fn get(&self) -> &T {
         unsafe_block!("We own the interior value" => { &*self.0 })
     }
 
@@ -93,7 +93,7 @@ where
         HandleExclusive(Box::into_raw(v), PhantomData)
     }
 
-    pub(super) fn get(self) -> &'a mut T {
+    pub(super) fn get(&mut self) -> &mut T {
         unsafe_block!("We own the interior value" => { &mut *(*self.0).get_raw() })
     }
 

--- a/native/c/src/handle/mod.rs
+++ b/native/c/src/handle/mod.rs
@@ -48,7 +48,7 @@ where
         HandleShared(Box::into_raw(v), PhantomData)
     }
 
-    pub(super) fn get(&self) -> &T {
+    pub(super) fn as_ref(&self) -> &T {
         unsafe_block!("We own the interior value" => { &*self.0 })
     }
 
@@ -93,7 +93,7 @@ where
         HandleExclusive(Box::into_raw(v), PhantomData)
     }
 
-    pub(super) fn get(&mut self) -> &mut T {
+    pub(super) fn as_mut(&mut self) -> &mut T {
         unsafe_block!("We own the interior value" => { &mut *(*self.0).get_raw() })
     }
 

--- a/native/c/src/handle/thread_bound.rs
+++ b/native/c/src/handle/thread_bound.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::{Cell, UnsafeCell},
+    cell::UnsafeCell,
     collections::HashMap,
     marker::PhantomData,
     mem,
@@ -73,14 +73,14 @@ lazy_static! {
 A value that's bound to the thread it's created on.
 */
 pub struct ThreadBound<T: ?Sized> {
-    thread_id: Cell<ThreadId>,
+    thread_id: ThreadId,
     inner: UnsafeCell<T>,
 }
 
 impl<T> ThreadBound<T> {
     pub(super) fn new(inner: T) -> Self {
         ThreadBound {
-            thread_id: Cell::new(get_thread_id()),
+            thread_id: get_thread_id(),
             inner: UnsafeCell::new(inner),
         }
     }
@@ -101,7 +101,7 @@ impl<T: ?Sized> ThreadBound<T> {
     fn check(&self) {
         let current = get_thread_id();
 
-        if self.thread_id.get() != current {
+        if self.thread_id != current {
             panic!("attempted to access resource from a different thread");
         }
     }

--- a/native/c/src/lib.rs
+++ b/native/c/src/lib.rs
@@ -125,7 +125,7 @@ ffi! {
         store: DbStoreHandle,
         reader: Out<DbReaderHandle>
     ) -> DbResult {
-        let store = store.get();
+        let store = store.as_ref();
 
         let handle = DbReaderHandle::alloc(DbReader {
             inner: thread_bound::DeferredCleanup::new(store.inner.read_begin()?),
@@ -143,7 +143,7 @@ ffi! {
         value_buf_len: size_t,
         actual_value_len: Out<size_t>
     ) -> DbResult {
-        let reader = reader.get();
+        let reader = reader.as_mut();
 
         let buf = unsafe_block!("The buffer lives as long as `db_read_next`, the length is within the buffer and the buffer won't be read before initialization" => value_buf.as_uninit_bytes_mut(value_buf_len));
 
@@ -191,7 +191,7 @@ ffi! {
         store: DbStoreHandle,
         writer: Out<DbWriterHandle>
     ) -> DbResult {
-        let store = store.get();
+        let store = store.as_ref();
 
         let handle = DbWriterHandle::alloc(DbWriter {
             inner: store.inner.write_begin()?,
@@ -208,7 +208,7 @@ ffi! {
         value: Ref<u8>,
         value_len: size_t
     ) -> DbResult {
-        let writer = writer.get();
+        let writer = writer.as_mut();
 
         let key = unsafe_block!("The key pointer lives as long as `db_write_set` and points to valid data" => key.as_ref());
         let value_slice = unsafe_block!("The buffer lives as long as `db_write_set` and the length is within the buffer" => value.as_bytes(value_len));
@@ -235,7 +235,7 @@ ffi! {
         store: DbStoreHandle,
         deleter: Out<DbDeleterHandle>
     ) -> DbResult {
-        let store = store.get();
+        let store = store.as_ref();
 
         let handle = DbDeleterHandle::alloc(DbDeleter {
             inner: store.inner.delete_begin()?,
@@ -250,7 +250,7 @@ ffi! {
         deleter: DbDeleterHandle,
         key: Ref<DbKey>
     ) -> DbResult {
-        let deleter = deleter.get();
+        let deleter = deleter.as_mut();
         
         let key = unsafe_block!("The key pointer lives as long as `db_delete_remove` and points to valid data" => key.as_ref());
 

--- a/native/c/src/lib.rs
+++ b/native/c/src/lib.rs
@@ -33,7 +33,6 @@ mod handle;
 mod is_null;
 mod read;
 mod result;
-mod thread_bound;
 
 pub use self::{
     handle::*,


### PR DESCRIPTION
We've introduced some new unsafe invariants to the `thread_bound` module that are only upheld by `HandleExclusive`, so I've moved the `thread_bound` module under `handle`. That way we don't need to leak that unsafety all the way up to the actual FFI calls.